### PR TITLE
feat: 게임 시작 기능구현

### DIFF
--- a/src/components/CameraMotion/index.jsx
+++ b/src/components/CameraMotion/index.jsx
@@ -30,13 +30,7 @@ export default function CameraMotion({
 }
 
 CameraMotion.propTypes = {
-  targetPosition: PropTypes.arrayOf(PropTypes.number),
-  lerpFactor: PropTypes.number,
-  targetDirection: PropTypes.arrayOf(PropTypes.number),
-}.isRequired;
-
-CameraMotion.defaultProps = {
-  targetPosition: [30, 10, 30],
-  lerpFactor: 0.01,
-  targetDirection: [0, 15, 0],
+  targetPosition: PropTypes.arrayOf(PropTypes.number).isRequired,
+  lerpFactor: PropTypes.number.isRequired,
+  targetDirection: PropTypes.arrayOf(PropTypes.number).isRequired,
 };

--- a/src/components/GameStart/index.jsx
+++ b/src/components/GameStart/index.jsx
@@ -7,49 +7,68 @@ import InputInterface from "../InputInterface";
 export default function GameStart() {
   const [playerName, setPlayerName] = useState("");
   const [error, setError] = useState("");
+  const checkUserInputRegExp = /^[가-힣a-zA-Z0-9]{1,10}$/.test(playerName);
 
-  const handleButtonClick = () => {
-    if (/^[가-힣a-zA-Z0-9]{1,10}$/.test(playerName)) {
-      const startTime = new Date().toLocaleString();
-      const startTimeList = [];
-      const storedTime = localStorage.getItem("startTime");
-
-      localStorage.setItem("playerName", playerName);
-
-      if (storedTime) {
-        const parsedTimeList = JSON.parse(storedTime);
-        const sessionRecord = { [startTime]: "" };
-
-        parsedTimeList.push(sessionRecord);
-        localStorage.setItem("startTime", JSON.stringify(parsedTimeList));
-      } else {
-        startTimeList.push({ [startTime]: "" });
-        localStorage.setItem("startTime", JSON.stringify(startTimeList));
-      }
-
-      setError("");
-    } else {
+  function handleButtonClick() {
+    if (!checkUserInputRegExp) {
       setError("이름은 한글, 영어, 숫자 혼용 10글자 이내여야 합니다.");
+      return;
     }
-  };
 
-  const handleInputChange = name => {
+    const startTime = new Date().toLocaleString();
+    const startTimeList = [];
+    const storedTime = localStorage.getItem("startTime");
+
+    localStorage.setItem("playerName", playerName);
+
+    if (storedTime) {
+      const parsedTimeList = JSON.parse(storedTime);
+      const sessionRecord = { [startTime]: "" };
+
+      parsedTimeList.push(sessionRecord);
+      localStorage.setItem("startTime", JSON.stringify(parsedTimeList));
+    } else {
+      startTimeList.push({ [startTime]: "" });
+      localStorage.setItem("startTime", JSON.stringify(startTimeList));
+    }
+
+    setError("");
+  }
+
+  function handleInputChange(name) {
     setPlayerName(name);
 
     if (name === "" || /^[가-힣a-zA-Z0-9]{1,10}$/.test(name)) {
       setError("");
     }
-  };
+  }
 
   return (
     <>
-      <Logo />
-      <InputInterface errorMessage={error} onChange={handleInputChange} />
+      <Logo
+        position={[10, 25, 10]}
+        scale={[25, 15, 0]}
+        rotation={[0.7, 0.7, -0.5]}
+      />
+      <InputInterface
+        position={[10, 16, 10]}
+        width="500px"
+        height="150px"
+        rotation={[0.6, 0.75, -0.42]}
+        fontSize="80px"
+        errorMessage={error}
+        onChange={handleInputChange}
+      />
       <CuboidButton
+        args={[12, 3, 3]}
+        position={[10, 10, 10]}
+        rotation={[11, 18.85, -8.6]}
         onClick={e => {
           e.stopPropagation();
           handleButtonClick();
         }}
+        color="Gold"
+        text="Start Button"
       />
     </>
   );

--- a/src/components/GameStart/index.jsx
+++ b/src/components/GameStart/index.jsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+
+import Logo from "../models/Logo";
+import CuboidButton from "../models/CuboidButton";
+import InputInterface from "../InputInterface";
+
+export default function GameStart() {
+  const [playerName, setPlayerName] = useState("");
+  const [error, setError] = useState("");
+
+  const handleButtonClick = () => {
+    if (/^[가-힣a-zA-Z0-9]{1,10}$/.test(playerName)) {
+      const startTime = new Date().toLocaleString();
+      const startTimeList = [];
+      const storedTime = localStorage.getItem("startTime");
+
+      localStorage.setItem("playerName", playerName);
+
+      if (storedTime) {
+        const parsedTimeList = JSON.parse(storedTime);
+        const sessionRecord = { [startTime]: "" };
+
+        parsedTimeList.push(sessionRecord);
+        localStorage.setItem("startTime", JSON.stringify(parsedTimeList));
+      } else {
+        startTimeList.push({ [startTime]: "" });
+        localStorage.setItem("startTime", JSON.stringify(startTimeList));
+      }
+
+      setError("");
+    } else {
+      setError("이름은 한글, 영어, 숫자 혼용 10글자 이내여야 합니다.");
+    }
+  };
+
+  const handleInputChange = name => {
+    setPlayerName(name);
+
+    if (name === "" || /^[가-힣a-zA-Z0-9]{1,10}$/.test(name)) {
+      setError("");
+    }
+  };
+
+  return (
+    <>
+      <Logo />
+      <InputInterface errorMessage={error} onChange={handleInputChange} />
+      <CuboidButton
+        onClick={e => {
+          e.stopPropagation();
+          handleButtonClick();
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/InputInterface/index.jsx
+++ b/src/components/InputInterface/index.jsx
@@ -47,21 +47,11 @@ export default function InputInterface({
 }
 
 InputInterface.propTypes = {
-  position: PropTypes.arrayOf(PropTypes.number),
-  width: PropTypes.string,
-  height: PropTypes.string,
-  rotation: PropTypes.arrayOf(PropTypes.number),
-  fontSize: PropTypes.string,
-  errorMessage: PropTypes.string,
-  onChange: PropTypes.func,
-}.isRequired;
-
-InputInterface.defaultProps = {
-  position: [10, 16, 10],
-  width: "500px",
-  height: "150px",
-  rotation: [0.6, 0.75, -0.42],
-  fontSize: "80px",
-  errorMessage: "",
-  onChange: () => {},
+  position: PropTypes.arrayOf(PropTypes.number).isRequired,
+  width: PropTypes.string.isRequired,
+  height: PropTypes.string.isRequired,
+  rotation: PropTypes.arrayOf(PropTypes.number).isRequired,
+  fontSize: PropTypes.string.isRequired,
+  errorMessage: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };

--- a/src/components/InputInterface/index.jsx
+++ b/src/components/InputInterface/index.jsx
@@ -9,12 +9,20 @@ const InputContainer = styled.div`
   align-items: center;
 `;
 
+const ErrorMessage = styled.div`
+  color: red;
+  margin-top: 10px;
+  font-size: 30px;
+`;
+
 export default function InputInterface({
   position,
   width,
   height,
   rotation,
   fontSize,
+  errorMessage,
+  onChange,
 }) {
   return (
     <Html position={position} rotation={rotation} transform occlude>
@@ -30,8 +38,10 @@ export default function InputInterface({
             borderRadius: "20px",
             fontSize,
           }}
+          onChange={e => onChange(e.target.value)}
         />
       </InputContainer>
+      {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </Html>
   );
 }
@@ -42,6 +52,8 @@ InputInterface.propTypes = {
   height: PropTypes.string,
   rotation: PropTypes.arrayOf(PropTypes.number),
   fontSize: PropTypes.string,
+  errorMessage: PropTypes.string,
+  onChange: PropTypes.func,
 }.isRequired;
 
 InputInterface.defaultProps = {
@@ -50,4 +62,6 @@ InputInterface.defaultProps = {
   height: "150px",
   rotation: [0.6, 0.75, -0.42],
   fontSize: "80px",
+  errorMessage: "",
+  onChange: () => {},
 };

--- a/src/components/models/CuboidButton.jsx
+++ b/src/components/models/CuboidButton.jsx
@@ -77,19 +77,10 @@ export default function CuboidButton({
 }
 
 CuboidButton.propTypes = {
-  args: PropTypes.arrayOf(PropTypes.number),
-  position: PropTypes.arrayOf(PropTypes.number),
-  rotation: PropTypes.arrayOf(PropTypes.number),
-  onClick: PropTypes.func,
-  color: PropTypes.string,
-  text: PropTypes.string,
-}.isRequired;
-
-CuboidButton.defaultProps = {
-  args: [12, 3, 3],
-  position: [10, 10, 10],
-  rotation: [11, 18.85, -8.6],
-  onClick: () => {},
-  color: "Gold",
-  text: "Start Button",
+  args: PropTypes.arrayOf(PropTypes.number).isRequired,
+  position: PropTypes.arrayOf(PropTypes.number).isRequired,
+  rotation: PropTypes.arrayOf(PropTypes.number).isRequired,
+  onClick: PropTypes.func.isRequired,
+  color: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
 };

--- a/src/components/models/Logo.jsx
+++ b/src/components/models/Logo.jsx
@@ -24,13 +24,7 @@ export default function Logo({ position, scale, rotation }) {
 }
 
 Logo.propTypes = {
-  position: PropTypes.arrayOf(PropTypes.number),
-  scale: PropTypes.arrayOf(PropTypes.number),
-  rotation: PropTypes.arrayOf(PropTypes.number),
-}.isRequired;
-
-Logo.defaultProps = {
-  position: [10, 25, 10],
-  scale: [25, 15, 0],
-  rotation: [0.7, 0.7, -0.5],
+  position: PropTypes.arrayOf(PropTypes.number).isRequired,
+  scale: PropTypes.arrayOf(PropTypes.number).isRequired,
+  rotation: PropTypes.arrayOf(PropTypes.number).isRequired,
 };


### PR DESCRIPTION
### [[FE] (튜토리얼 클리어시) 게임 시작 기능](https://www.notion.so/FE-7f84edf96ca74931a12aa77f2cf7e516?pvs=4)

### 설명
**튜토리얼 클리어 시점에 게임 시작화면 레이이아웃에서 게임시작 기능을 구현했습니다. 내용은 아래와 같습니다.**
- Player Name 이 입력되지 않았을 때 Game Start 버튼 기능 (onClick event) 비활성화
- Player Name 이 입력되면 Game Start 버튼 기능 (onClick event) 활성화
- Game Start 버튼을 누르면 플레이어 이름과 게임 시작 시간을 로컬 스토리지에 저장

**상세내용은 아래와 같습니다.**
- 기존 `InputInterface` 컴포넌트
1.  기존 코드만으로는 재활용이 불가능하여, `ErrorMessage` div와 `errorMessage` ,`onChange` props를 추가하여 작업하였습니다. `errorMessage`의 `default` 값은 `"" `입니다.
2. `GameStart` 컴포넌트에서  유효성 검사를 한 후에 props를 넘겨주도록 작성했습니다.
- GameStart 컴포넌트 
1. `handleButtonClick`으로  `CuboidButton` 클릭 시 유효성 검사를 진행해주며,
유효성 검사에 통과하지 못할 시 setError를  해주고, `CuboidButton`에 prop 으로 넘겨줍니다.
2. 작성해놓은 값을 유효한 값으로 바꾸면 다시 error div 가 사라지는 `handleInputChange` 를 
`InputInterface`에 prop으로 넘겨줍니다.
- GameStart 컴포넌트에서 유효성 검사 통과 시 
1. `playerName`을 localStorage에 저장합니다.
2. localStorage에 배열 내 startTime 을 key값으로 객체형태로 넣어주었습니다. 
ex) [{2024. 2. 5. 오전 1:45:19: ""}, {2024. 2. 5. 오전 1:45:19: ""}]
추후 해당 키(startTime) 값에 게임 스코어를 넣어주기 위함입니다.


<br/>

### 리뷰 받고 싶은 내용 or 컨펌 필요 부분
- 현재 LocalStorage에 한 명의 플레이어의 시작 시간과 스코어를 담아줄 배열을 만들어 주는 기능을 포함했습니다.
[{2024. 2. 5. 오전 1:45:19: ""}, {2024. 2. 5. 오전 1:45:19: ""}] 와 같은 형태로 저장이 되고 있습니다.
해당 데이터 생성과 관련하여 좋은 의견 주시면 적극 반영하겠습니다.

### PR전 확인사항

- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.

### 스크린샷
![Monosnap screencast 2024-02-05 01-27-35](https://github.com/howinteraction/interaction/assets/116258834/ffa59012-7898-40fa-944f-770f3ffa5c09)


