### PR TITLE
feat: 스테이지1 화면 레이아웃 구성

### DIFF
--- a/src/components/Stages/StageOne.jsx
+++ b/src/components/Stages/StageOne.jsx
@@ -1,0 +1,81 @@
+import { Canvas } from "@react-three/fiber";
+import { PointerLockControls, Sky } from "@react-three/drei";
+import { Physics, RigidBody } from "@react-three/rapier";
+
+import Sphere from "../models/Sphere";
+import Box from "../models/Box";
+import Capsule from "../models/Capsule";
+import Cylinder from "../models/Cylinder";
+import Torus from "../models/Torus";
+import Cone from "../models/Cone";
+import Plane from "../models/Plane";
+
+import TutorialBackground from "../models/TutorialBackground";
+import Player from "../Player";
+
+import Stopwatch from "../Stopwatch";
+import SubTitle from "../Subtitle";
+
+export default function StageOne() {
+  return (
+    <Canvas>
+        <PointerLockControls />
+        <Sky sunPosition={[0, 10, 5]} />
+        <ambientLight intensity={1} />
+        <Physics>
+          <RigidBody colliders={false}>
+            <TutorialBackground />
+          </RigidBody>
+          <RigidBody>
+            <Sphere position={[10, 2.9, 2]} args={[1]} color="red" />
+          </RigidBody>
+          <RigidBody>
+            <Box position={[-10, 2.8, -2]} args={[2, 2, 2]} color="blue" />
+          </RigidBody>
+          <RigidBody>
+            <Capsule
+              position={[6, 2.7, -3]}
+              args={[1, 1, 4, 8]}
+              color="yellow"
+            />
+          </RigidBody>
+          <RigidBody>
+            <Cylinder
+              position={[-1, 2.6, -8]}
+              args={[0.5, 0.5, 1.5, 16]}
+              color="orange"
+            />
+          </RigidBody>
+          <RigidBody>
+            <Torus
+              position={[3, 1.25, 6]}
+              args={[1, 0.25, 8, 50]}
+              color="green"
+            />
+          </RigidBody>
+          <RigidBody>
+            <Cone position={[-6, 2, 5]} args={[1, 2, 20]} color="purple" />
+          </RigidBody>
+          <Plane
+            position={[-19.9, 20, 1]}
+            rotateX={0}
+            rotateY={1.55}
+            color="black"
+            args={[10, 10]}
+          />
+          <Player />
+        </Physics>
+        <Stopwatch position={[15, 24, -19.8]} rotation={[19, 6.3, 0]} />
+        <SubTitle
+          position={[1, 14, -18]}
+          rotation={[19, 6.3, 0]}
+          subtitle="Drop the Object top to Bottom"
+        />
+        <SubTitle
+          position={[0.9, 8, -18]}
+          rotation={[19, 6.3, 0]}
+          subtitle="Please Click Screen to PlayGame"
+        />
+      </Canvas>
+  );
+}

--- a/src/components/models/Plane.jsx
+++ b/src/components/models/Plane.jsx
@@ -1,0 +1,18 @@
+import PropTypes from "prop-types";
+
+export default function Plane({ position, args, color, rotateX, rotateY }) {
+  return (
+    <mesh position={position} rotation-x={rotateX} rotation-y={rotateY}>
+      <planeGeometry args={args} />
+      <meshStandardMaterial attach="material" color={color} />
+    </mesh>
+  );
+}
+
+Plane.propTypes = {
+  position: PropTypes.arrayOf(PropTypes.number).isRequired,
+  args: PropTypes.arrayOf(PropTypes.number).isRequired,
+  color: PropTypes.string.isRequired,
+  rotateX: PropTypes.number.isRequired,
+  rotateY: PropTypes.number.isRequired,
+};


### PR DESCRIPTION
### [[FE] 스테이지1 화면 레이아웃 구성](https://www.notion.so/FE-1-816487f2349240c39712394faa49d955)

### 설명

- 스테이지 1 화면 레이아웃 구성입니다.
- 필요한 Object들을 배치해 놓았습니다.

### PR전 확인사항

- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.

### (필요시) 스크린샷
<img width="1440" alt="스크린샷 2024-02-06 20 09 12" src="https://github.com/howinteraction/interaction/assets/126459089/2b6b1c8a-0872-45d9-8d3c-fd4e674829b9">


