### PR TITLE
feat: 드래그 컨트롤 기능 구현 및 새로운 배경모델 glb 파일 및 컴포넌트 추가

### DIFF
--- a/src/components/DragControl/index.jsx
+++ b/src/components/DragControl/index.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import { PointerLockControls } from "@react-three/drei";
+
+import * as THREE from "three";
+
+export default function DragControl() {
+  const { camera, scene, raycaster } = useThree();
+  const [selectedObject, setSelectedObject] = useState(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [initialDistance, setInitialDistance] = useState(null);
+
+  const controls = useRef();
+
+  useEffect(() => {
+    controls.current.lock();
+
+    const handleClick = () => {
+      const center = new THREE.Vector2(0, 0);
+
+      raycaster.setFromCamera(center, camera);
+
+      const intersection = raycaster.intersectObjects(scene.children, true);
+
+      if (intersection.length > 0 && !isDragging) {
+        setSelectedObject(intersection[0].object);
+
+        const distance = intersection[0].object.position.distanceTo(
+          camera.position,
+        );
+
+        setInitialDistance(distance);
+        setIsDragging(true);
+      } else {
+        setIsDragging(false);
+        setSelectedObject(null);
+      }
+    };
+
+    document.addEventListener("click", handleClick);
+
+    return () => document.removeEventListener("click", handleClick);
+  }, [camera, scene.children, raycaster, isDragging]);
+
+  useFrame(() => {
+    if (selectedObject && isDragging) {
+      const direction = new THREE.Vector3();
+
+      camera.getWorldDirection(direction);
+
+      const newPosition = direction
+        .multiplyScalar(initialDistance)
+        .add(camera.position);
+
+      selectedObject.position.copy(newPosition);
+      selectedObject.lookAt(camera.position);
+    }
+  });
+
+  return (
+    <PointerLockControls ref={controls} />
+  );
+}

--- a/src/components/DragControl/index.jsx
+++ b/src/components/DragControl/index.jsx
@@ -9,7 +9,6 @@ export default function DragControl() {
   const [selectedObject, setSelectedObject] = useState(null);
   const [isDragging, setIsDragging] = useState(false);
   const [initialDistance, setInitialDistance] = useState(null);
-
   const controls = useRef();
 
   useEffect(() => {
@@ -57,7 +56,5 @@ export default function DragControl() {
     }
   });
 
-  return (
-    <PointerLockControls ref={controls} />
-  );
+  return <PointerLockControls ref={controls} />;
 }

--- a/src/components/models/GarageBackground.jsx
+++ b/src/components/models/GarageBackground.jsx
@@ -1,0 +1,13 @@
+import { useGLTF } from "@react-three/drei";
+import { CuboidCollider, RigidBody } from "@react-three/rapier";
+
+export default function WesternTown() {
+  const gltf = useGLTF("/assets/glb/garage.glb");
+
+  return (
+    <RigidBody type="fixed" colliders={false}>
+      <primitive object={gltf.scene} />
+      <CuboidCollider args={[100, 0.01, 100]} position={[0, 0, 0]} />
+    </RigidBody>
+  );
+}


### PR DESCRIPTION
### [[FE] 스테이지1 오브젝트 드래그 & 플레이어 이동 상호작용 기능](https://www.notion.so/FE-1-ce5e15979f804f3ea97cccf578b596e4?pvs=4)

### 설명
**player와 상호작용이 가능한 오브젝트 드래그 컨트롤 기능을 구현했습니다.
내용은 아래와 같습니다.**
- 물체를 잡고 드래그 및 플레이어 이동 시 물체와 플레이어 간의 상호작용을 일정하게 적용
   -  플레이어가 마우스 왼쪽 클릭으로 물체를 잡을 수 있음
    -  플레이어가 물체를 잡고 움직일 수 있어야 하고, 물체도 동일하게 움직여야 함
    -  플레이어가 물체를 잡았으면 해당 물체가 카메라 중간에 있어야함
    - 물체의 움직임은 플레이어와 물체의 거리를 반지름으로 하는 반구형태로 움직여야 함
    
- 상세 내용은 아래와 같습니다.
   - 기존 튜토리얼 작업에서 사용되었던 useDrag, threejs 상에서 사용했던 drag control 대신 다른 방식으로 접근하였습니다. 화면 정 중앙에 잡은 오브젝트를 위치시키기 위함입니다.
      - 클릭이벤트가 발생하면 아래와 같은 event가 발생합니다.
      - `raycaster` 를 이용해서 가상의 선을 화면의 정중앙에 맞춰줍니다. 이때 화면의 정중앙은 Vector2(0, 0) 입니다.
      - 가상의 선을 3차원 내에 투영하기 위해, `raycaster`의 `setFromCamera`를 사용하였습니다.
      - `raycaster.intersectObjects(scene.children, true);` 로, 발사한 가상 선 내 위치하는 scene 내 모든 자식요소들을 배열로 저장합니다.
      - 해당 children 중 첫번째 요소가 저희가 선택한 오브젝트가 됩니다.
   - 해당 붙잡을 오브젝트와 player camera와의 위치가 일정하게 유지되도록 했습니다.
      - 클릭 이벤트 시 player camera와 오브젝트의 x, y, z 거리차를 계산하여 저장합니다.
   - `useFrame` 내에서 일정하게 오브젝트의 위치를 바꿔주었습니다.
      - 선택된 물체가 있거나 드래그 중이면 camera의 `world direction` 을 구해준 후 그 방향에 스칼라 값인 초기에 구한 거리를 곱하여 최종 벡터값을 구해주었습니다.
      - 물체의 위치값에 새로 구한 값을 넣어주어 드래그를 직접 구현했습니다.
      - 물체가 이동할 때 player를 바라보는 면이 일정해야 한다라는 생각에 기존에 저희가 가정했던 쿼터니언을 이용한 접근 대신,  `selectedObject.lookAt(camera.position);` 로 드래그 선택한 물체가 player camera를 바라보도록 했습니다.


### 리뷰 받고 싶은 내용 or 컨펌 필요 부분
- 현재 PointerLockControls 를 해당 컴포넌트에 추가하여 , 게임 stage 시작시 강제로 포인터락이 걸리도록 하였습니다. 해당 사항에 대해 이상 있으시면 적극적으로 의견 부탁드리겠습니다.
- 현재 draggable한 오브젝트를 선택적으로 넣어줄 수 있는 기능이 구현되지 않았습니다. 빠른 시일 내로 refactoring 하여 올리도록 하겠습니다.

### PR전 확인사항

- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.

### 스크린샷
![drag_control](https://github.com/howinteraction/interaction/assets/116258834/970133fb-5118-4e4d-b565-9ef11eba7cc9)

