### PR TITLE
feat: 스테이지 클리어 화면 구현

### DIFF
--- a/src/components/StageClearModal/index.jsx
+++ b/src/components/StageClearModal/index.jsx
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ModalContent = styled.div`
+  background: #fff;
+  padding: 20px;
+  border-radius: 5px;
+  text-align: center;
+`;
+
+const CloseButton = styled.button`
+  background: #007bff;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 16px;
+  margin-top: 10px;
+`;
+
+export default function StageClearModal({ onClose }) {
+  function handleModalClick(event) {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  }
+
+  return (
+    <ModalContainer onClick={handleModalClick}>
+      <ModalContent>
+        <h2>Congratulations!</h2>
+        <p>You have cleared the stage. Would you like to play next stage?</p>
+        <CloseButton onClick={onClose}>Next Stage</CloseButton>
+      </ModalContent>
+    </ModalContainer>
+  );
+};

--- a/src/components/StageClearModal/index.jsx
+++ b/src/components/StageClearModal/index.jsx
@@ -1,33 +1,34 @@
+import PropTypes from "prop-types";
 import styled from "styled-components";
 
 const ModalContainer = styled.div`
+  display: flex;
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
 `;
 
 const ModalContent = styled.div`
-  background: #fff;
   padding: 20px;
+  background: #fff;
   border-radius: 5px;
   text-align: center;
 `;
 
 const CloseButton = styled.button`
+  padding: 10px 20px;
+  margin-top: 10px;
   background: #007bff;
   color: #fff;
   border: none;
-  padding: 10px 20px;
   border-radius: 3px;
   cursor: pointer;
   font-size: 16px;
-  margin-top: 10px;
 `;
 
 export default function StageClearModal({ onClose }) {
@@ -46,4 +47,8 @@ export default function StageClearModal({ onClose }) {
       </ModalContent>
     </ModalContainer>
   );
+}
+
+StageClearModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
### [[FE] 스테이지 클리어 화면 구현](https://www.notion.so/FE-6c35d6b9472a4ebd8bea7b16fb0699bb?pvs=4)
### 설명
**화면 중앙에 모달창으로  Next Stage 버튼 배치하여 구현 완료하였습니다.
상세 작업 내용은 아래와 같습니다.**
- `onClose` 를 `props`로 받고 모달창 밖 또는 `Next Stage`버튼을 클릭했을 때 모달창이 꺼짐

### 리뷰 받고 싶은 내용 or 컨펌 필요 부분

스테이지 1, 2, 3 클리어시 떠야하는 모달이라서 아직 스테이지 1이 구현되지 않아 테스트는 못했습니다.
대안으로 튜토리얼 스테이지에서 테스트 하려하였으나 튜토리얼 스테이지는 `Canvas tag` 에 감싸져 있어서 `StageClearModal` 을 튜토리얼 컴포넌트에 꽂지 못하였습니다. 부득이 `Game Start`버튼을 누른 직후 모달창 생성 여부로 테스트 한 점 감안해주시기바람니다.
추후 이 컴포넌트를 사용할 시 `close` 상태를 `boolean`으로 전달받아 다음 스테이지를 렌더링 하는 식으로 구현하면 될 것 같습니다.  


### PR전 확인사항

- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.

### 스크린샷
<img width="1020" alt="스크린샷 2024-02-12 오후 2 03 53" src="https://github.com/howinteraction/interaction/assets/101324787/0e14d9ec-51d9-49a6-892e-4ae82fed5968">
