### PR TITLE
refactor: 드래그 컨트롤 기능 rapier 물리엔진 적용

### DIFF
--- a/src/components/DragControl/index.jsx
+++ b/src/components/DragControl/index.jsx
@@ -28,7 +28,7 @@ export default function DragControl() {
       const adjustOrigin = origin.add(direction.multiplyScalar(originOffset));
       const ray = new RAPIER.Ray(adjustOrigin, direction);
       const castRay = world.castRay(ray, maxToi, true);
-      const {handle} = castRay.collider.parent();
+      const { handle } = castRay.collider.parent();
       const selectedRigidBody = world.getRigidBody(handle);
 
       if (castRay && !isDragging && selectedRigidBody.userData) {


### PR DESCRIPTION
### [[FE] 스테이지1 오브젝트 드래그 & 플레이어 이동 상호작용 기능](https://www.notion.so/FE-1-ce5e15979f804f3ea97cccf578b596e4?pvs=4)

### 설명
**오브젝트 드래그 컨트롤 기능에 물리엔진을 적용하여 리팩터링 하였습니다.
내용은 아래와 같습니다.**
   - 기존 `useThree`의 `raycaster` 대신 `rapier`의 `castRay`로 접근하였습니다. `RigidBody` 에 물리값 적용을 위함입니다.
      - 클릭을 하면 아래와 같은 event가 발생합니다.
      - `RAPIER`의 `castRay` 를 이용해서 가상의 선을 화면의 정중앙에 맞춰줍니다.
        - 이 때, `originOffset`을 적용합니다. 이유는 기존 `Player`코드에서 `collider` 에 `camera`가 부착되어있는 형태를 취하고 있고,
        `castRay`를 쏘면 처음 맞닿는 `collider`를 기준으로 값을 반환하기 때문에 offset을 주지 않고 castRay를 사용하면 Player의 collider의 값을 반환합니다.
        이 문제를 해결하기 위해 카메라의 `direction`벡터 방향으로 일정거리를 띄워줍니다.
        - 위의 과정을 거치면 반환되는 `castRay`값에서 `.collider.parent().handle` 값은 사용자가 선택한 오브젝트의 `RigidBody`의 handle을 반환해줍니다.
        - `RigidBody`에서 `handle` 값은 물리 엔진 내부에서 특정 `RigidBody` 객체를 식별하기 위해 사용되는 고유 식별자입니다.
        - `world.getRigidBody(handle)`로 사용자가 선택한 오브젝트의 RIgidBody를 선택할 수 있습니다.
        - `useFrame` 에서는 `handle` 값을 이용하여, 선택한 `RigidBody`에 `setTranslation`을 해주었습니다.
      - 오브젝트를 클릭하여 붙잡고 이동하거나 가만히 있을 때, 오브젝트가 심하게 요동치는 현상도 해결하였습니다.
        - [`useFrame`내에서 `selectedRigidBody.setBodyType(2)`로 선택한 `RigidBody`에 `KinematicPositionBased` 속성을 적용](https://github.com/howinteraction/interaction/compare/feature/stage1-drag-control?expand=1#diff-c93448b23c466d0f392b97b4efe092c849f9c2d4464337816a9869800fc5d625R78)해 주었습니다.
          - 0: Dynamic,  1: Fixed,  2: KinematicPositionBased,  3: KinematicVelocityBased
        - `KinematicPositionBased`는 개발자가 코드를 통해 직접 위치를 제어할 수 있으며, 물리 엔진은 이 객체에 대한 충돌 감지만 수행하며 중력값의 영향은 받지 않습니다.
        - 클릭하여 물체를 이동시킨 후, 한번 더 클릭하면 중력의 영향을 받을 수 있도록 [`selectedRigidBody.setBodyType(0)`으로 dynamic 속성을 적용](https://github.com/howinteraction/interaction/compare/feature/stage1-drag-control?expand=1#diff-c93448b23c466d0f392b97b4efe092c849f9c2d4464337816a9869800fc5d625R49)해 주었습니다.
  

### 리뷰 받고 싶은 내용 or 컨펌 필요 부분
- 현재 `DragControl`에서 원근법에 의한 착시현상 로직을 추가로 적용해야 하므로, 기존 작업하시던 부분에서 충돌 혹은 이상이 있으실 시에는 리뷰 남겨주시면 적극 반영하여 수정하도록 하겠습니다.

### 기타 내용
- 기존의 오브젝트 드래그에서 첫 클릭 시 오브젝트의 위치가 튀던 현상은, RigidBody의 위치값이 아닌 mesh의 위치값을 적용시키려 하여 발생하던 현상이었습니다.
- 사용하던 오브젝트 모델 컴포넌트들의 position 값들을 모두 지워주시고
```
 <RigidBody
  userData={{ ["draggable"]: true }}
  position={[3, 1.25, 6]}
  lockRotations
>
  <Torus args={[1, 0.25, 8, 50]} color="green" />
</RigidBody>
```
```
import PropTypes from "prop-types";

export default function Torus({ args, color }) {
  return (
    <mesh>
      <torusGeometry args={args} />
      <meshStandardMaterial attach="material" color={color} />
    </mesh>
  );
}

Torus.propTypes = {
  args: PropTypes.arrayOf(PropTypes.number).isRequired,
  color: PropTypes.string.isRequired,
};
```

와 같이 수정해주시면 될 것 같습니다.


### PR전 확인사항
- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.

### 스크린샷
![drag_rapier](https://github.com/howinteraction/interaction/assets/116258834/cfc0ad9d-059f-4a68-b22f-622e796e5429)

