### PR TITLE
refactor: 드래그 컨트롤 백그라운드 모델 벽 뚫는 현상 및 재클릭시 낙하하지 않는 현상 해결

### DIFF
--- a/src/components/DragControl/index.jsx
+++ b/src/components/DragControl/index.jsx
@@ -7,9 +7,9 @@ import * as THREE from "three";
 import * as RAPIER from "@dimforge/rapier3d-compat";
 
 import PropTypes from "prop-types";
-import clamp from "../../utils/clamp";
+import restrictPosition from "../../utils/restrictPosition";
 
-export default function DragControl({ minX, maxX, minZ, maxZ }) {
+export default function DragControl({ minX, maxX, maxY, minZ, maxZ }) {
   const controlsRef = useRef();
   const [selectedHandle, setSelectedHandle] = useState(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -82,10 +82,13 @@ export default function DragControl({ minX, maxX, minZ, maxZ }) {
         .multiplyScalar(initialDistance)
         .add(camera.position);
       const selectedRigidBody = world.getRigidBody(selectedHandle);
-      const adjustedPositionX = clamp(newPosition.x, minX, maxX);
-      const adjustedPositionY =
-        newPosition.y < clickedPosition.y ? clickedPosition.y : newPosition.y;
-      const adjustedPositionZ = clamp(newPosition.z, minZ, maxZ);
+      const adjustedPositionX = restrictPosition(newPosition.x, minX, maxX);
+      const adjustedPositionY = restrictPosition(
+        newPosition.y,
+        clickedPosition.y,
+        maxY,
+      );
+      const adjustedPositionZ = restrictPosition(newPosition.z, minZ, maxZ);
 
       selectedRigidBody.setTranslation(
         new THREE.Vector3(
@@ -106,6 +109,7 @@ export default function DragControl({ minX, maxX, minZ, maxZ }) {
 DragControl.propTypes = {
   minX: PropTypes.number.isRequired,
   maxX: PropTypes.number.isRequired,
+  maxY: PropTypes.number.isRequired,
   minZ: PropTypes.number.isRequired,
   maxZ: PropTypes.number.isRequired,
 };

--- a/src/components/DragControl/index.jsx
+++ b/src/components/DragControl/index.jsx
@@ -6,11 +6,15 @@ import { useRapier } from "@react-three/rapier";
 import * as THREE from "three";
 import * as RAPIER from "@dimforge/rapier3d-compat";
 
-export default function DragControl() {
+import PropTypes from "prop-types";
+import clamp from "../../utils/clamp";
+
+export default function DragControl({ minX, maxX, minZ, maxZ }) {
   const controlsRef = useRef();
   const [selectedHandle, setSelectedHandle] = useState(null);
   const [isDragging, setIsDragging] = useState(false);
   const [initialDistance, setInitialDistance] = useState(null);
+  const [clickedPosition, setClickedPosition] = useState(null);
   const { camera } = useThree();
   const { world } = useRapier();
 
@@ -28,42 +32,47 @@ export default function DragControl() {
       const adjustOrigin = origin.add(direction.multiplyScalar(originOffset));
       const ray = new RAPIER.Ray(adjustOrigin, direction);
       const castRay = world.castRay(ray, maxToi, true);
-      const { handle } = castRay.collider.parent();
-      const selectedRigidBody = world.getRigidBody(handle);
 
-      if (castRay && !isDragging && selectedRigidBody.userData) {
-        const selectedRigidBodyPositionVector = new THREE.Vector3(
-          selectedRigidBody.translation().x,
-          selectedRigidBody.translation().y,
-          selectedRigidBody.translation().z,
-        );
+      if (castRay) {
+        const { handle } = castRay.collider.parent();
+        const selectedRigidBody = world.getRigidBody(handle);
 
-        const distance = selectedRigidBodyPositionVector.distanceTo(
-          camera.position,
-        );
+        if (!isDragging && selectedRigidBody.userData?.isDraggable) {
+          const selectedRigidBodyPositionVector = new THREE.Vector3(
+            selectedRigidBody.translation().x,
+            selectedRigidBody.translation().y,
+            selectedRigidBody.translation().z,
+          );
 
-        setIsDragging(true);
-        setSelectedHandle(handle);
-        setInitialDistance(distance);
-      } else {
-        selectedRigidBody.setBodyType(0);
+          setClickedPosition(selectedRigidBody.translation());
 
-        setIsDragging(false);
-        setSelectedHandle(null);
-        setInitialDistance(null);
+          const distance = selectedRigidBodyPositionVector.distanceTo(
+            camera.position,
+          );
+
+          setIsDragging(true);
+          setSelectedHandle(handle);
+          setInitialDistance(distance);
+        } else if (selectedHandle && isDragging) {
+          world.getRigidBody(selectedHandle).setBodyType(0);
+
+          setIsDragging(false);
+          setSelectedHandle(null);
+          setInitialDistance(null);
+        }
       }
     };
 
     document.addEventListener("click", handleClick);
 
     return () => document.removeEventListener("click", handleClick);
-  }, [camera, isDragging, world]);
+  }, [camera, isDragging, world, selectedHandle, clickedPosition]);
 
   useFrame(() => {
     if (
       selectedHandle &&
       isDragging &&
-      world.getRigidBody(selectedHandle).userData
+      world.getRigidBody(selectedHandle).userData?.isDraggable
     ) {
       const direction = new THREE.Vector3();
 
@@ -73,11 +82,30 @@ export default function DragControl() {
         .multiplyScalar(initialDistance)
         .add(camera.position);
       const selectedRigidBody = world.getRigidBody(selectedHandle);
+      const adjustedPositionX = clamp(newPosition.x, minX, maxX);
+      const adjustedPositionY =
+        newPosition.y < clickedPosition.y ? clickedPosition.y : newPosition.y;
+      const adjustedPositionZ = clamp(newPosition.z, minZ, maxZ);
 
-      selectedRigidBody.setTranslation(newPosition, true);
+      selectedRigidBody.setTranslation(
+        new THREE.Vector3(
+          adjustedPositionX,
+          adjustedPositionY,
+          adjustedPositionZ,
+        ),
+        true,
+      );
+
       selectedRigidBody.setBodyType(2);
     }
   });
 
   return <PointerLockControls ref={controlsRef} />;
 }
+
+DragControl.propTypes = {
+  minX: PropTypes.number.isRequired,
+  maxX: PropTypes.number.isRequired,
+  minZ: PropTypes.number.isRequired,
+  maxZ: PropTypes.number.isRequired,
+};

--- a/src/components/Stages/StageOne.jsx
+++ b/src/components/Stages/StageOne.jsx
@@ -50,7 +50,7 @@ export default function StageOne() {
           shadow-camera-far={1000}
         />
         <Physics>
-          <DragControl minX={-19} maxX={19} minZ={-19} maxZ={19} />
+          <DragControl minX={-19} maxX={19} maxY={29} minZ={-19} maxZ={19} />
           <RigidBody type="fixed" colliders={false}>
             <TutorialBackground />
           </RigidBody>

--- a/src/components/Stages/StageOne.jsx
+++ b/src/components/Stages/StageOne.jsx
@@ -50,7 +50,7 @@ export default function StageOne() {
           shadow-camera-far={1000}
         />
         <Physics>
-          <DragControl />
+          <DragControl minX={-19} maxX={19} minZ={-19} maxZ={19} />
           <RigidBody type="fixed" colliders={false}>
             <TutorialBackground />
           </RigidBody>

--- a/src/utils/clamp.js
+++ b/src/utils/clamp.js
@@ -1,3 +1,0 @@
-export default function clamp(value, min, max) {
-  return Math.max(min, Math.min(value, max));
-}

--- a/src/utils/clamp.js
+++ b/src/utils/clamp.js
@@ -1,0 +1,3 @@
+export default function clamp(value, min, max) {
+  return Math.max(min, Math.min(value, max));
+}

--- a/src/utils/restrictPosition.js
+++ b/src/utils/restrictPosition.js
@@ -1,0 +1,3 @@
+export default function restrictPosition(value, min, max) {
+  return Math.max(min, Math.min(value, max));
+}


### PR DESCRIPTION
### [[FE] 스테이지1 오브젝트 드래그 & 플레이어 이동 상호작용 기능](https://www.notion.so/FE-1-ce5e15979f804f3ea97cccf578b596e4?pvs=4)

### 설명
**오브젝트 드래그 컨트롤 기능 사용 시 stageOne에서 백그라운드 모델의 벽을 뚫는 현상 및 드래그 중 다른 오브젝트가 클릭되면 낙하하지 않는 현상 해결하였습니다.
내용은 아래와 같습니다.**
   - handleClick 이벤트 발생 시 조건문을 수정하여 다른 곳을 클릭해도 기존 드래그 중인 물체가 낙하되게 수정하였습니다.
   - `useState`로`clickedPosition` 클릭 시 담아주었습니다. 이 값으로 `useFrame`에서 y축 값을 따로 지정해주지 않도록 해결하였습니다.
   - adjustedPosition x, y, z 값을 연산하여 백그라운드 모델의 모든 면을 오브젝트가 뚫고 나가지 않도록 해결하였습니다.
   - `useFrame` 내부에서 벽을 뚫지 않도록 조정해주는 [`adjustedPosition` 관련 로직](https://github.com/howinteraction/interaction/compare/feature/drag-control-clamp?expand=1#diff-c93448b23c466d0f392b97b4efe092c849f9c2d4464337816a9869800fc5d625R85-R88)을  [유틸함수로 분리](https://github.com/howinteraction/interaction/compare/feature/drag-control-clamp?expand=1#diff-03a7ebcec6926b931d616027e9e907214af4b98ac83e75dd03fbd2633e0517faR1-R3) 후 각 [Stage에서 호출 시 props로 max, min 값을 넘겨주도록 수정](https://github.com/howinteraction/interaction/compare/feature/drag-control-clamp?expand=1#diff-72ebae9365874053b710045329a7d76cd58268e2d8d55c2ed9cd7a4b2fd71538R53)하였습니다.
  
### 리뷰 받고 싶은 내용 or 컨펌 필요 부분
- 현재 `DragControl`에서 원근법에 의한 착시현상 로직을 추가로 적용해야 하므로, 기존 작업하시던 부분에서 충돌 혹은 이상이 있으실 시에는 리뷰 남겨주시면 적극 반영하여 수정하도록 하겠습니다.


### PR전 확인사항

- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.

### 스크린샷
![벽 뚫기 및 드랍 해결](https://github.com/howinteraction/interaction/assets/116258834/862a5cc1-ce7a-4d34-8d12-d95e295dfaa9)
