### PR TITLE
feat: 스테이지1 클리어 기능 및 클리어 modal창 렌더링

### DIFF
--- a/src/components/DragControl/index.jsx
+++ b/src/components/DragControl/index.jsx
@@ -16,10 +16,10 @@ export default function DragControl({
   minZ,
   maxZ,
   boxSize,
-  setBoxSize
+  setBoxSize,
+  controlsRef,
 }) {
   const meshScaleRef = useRef();
-  const controlsRef = useRef();
   const [selectedHandle, setSelectedHandle] = useState(null);
   const [isDragging, setIsDragging] = useState(false);
   const [initialDistance, setInitialDistance] = useState(null);
@@ -64,8 +64,10 @@ export default function DragControl({
           setInitialDistance(distance);
         } else if (selectedHandle && isDragging) {
           world.getRigidBody(selectedHandle).setBodyType(0);
+          if (meshScaleRef.current) {
+            setBoxSize(meshScaleRef.current);
+          }
 
-          setBoxSize(meshScaleRef.current);
           setIsDragging(false);
           setSelectedHandle(null);
           setInitialDistance(null);
@@ -96,14 +98,14 @@ export default function DragControl({
       const adjustedPositionY = restrictPosition(
         newPosition.y,
         clickedPosition.y,
-        maxY
+        maxY,
       );
       const adjustedPositionZ = restrictPosition(newPosition.z, minZ, maxZ);
 
       const adjustedPosition = new THREE.Vector3(
         adjustedPositionX,
         adjustedPositionY,
-        adjustedPositionZ
+        adjustedPositionZ,
       );
 
       const finalDistance = adjustedPosition.distanceTo(camera.position);
@@ -119,11 +121,11 @@ export default function DragControl({
           const scale = 1 + heightRatio;
           const newSize = boxSize * scale;
 
-          selectedRigidBody.collider(0).setHalfExtents(new THREE.Vector3(
-            newSize / 2,
-            newSize / 2,
-            newSize / 2
-          ));
+          selectedRigidBody
+            .collider(0)
+            .setHalfExtents(
+              new THREE.Vector3(newSize / 2, newSize / 2, newSize / 2),
+            );
 
           meshScaleRef.current = newSize;
         } else {
@@ -131,11 +133,15 @@ export default function DragControl({
           const minimumSize = 0.5;
           const adjustedSize = newSize < minimumSize ? minimumSize : newSize;
 
-          selectedRigidBody.collider(0).setHalfExtents(new THREE.Vector3(
-            adjustedSize / 2,
-            adjustedSize / 2,
-            adjustedSize / 2
-          ));
+          selectedRigidBody
+            .collider(0)
+            .setHalfExtents(
+              new THREE.Vector3(
+                adjustedSize / 2,
+                adjustedSize / 2,
+                adjustedSize / 2,
+              ),
+            );
 
           meshScaleRef.current = adjustedSize;
         }
@@ -163,6 +169,12 @@ DragControl.propTypes = {
   maxY: PropTypes.number.isRequired,
   minZ: PropTypes.number.isRequired,
   maxZ: PropTypes.number.isRequired,
-  boxSize: PropTypes.number.isRequired,
-  setBoxSize: PropTypes.func.isRequired,
+  controlsRef: PropTypes.instanceOf(Object).isRequired,
+  boxSize: PropTypes.number,
+  setBoxSize: PropTypes.func,
+};
+
+DragControl.defaultProps = {
+  boxSize: 2,
+  setBoxSize: () => {},
 };

--- a/src/components/Player/index.jsx
+++ b/src/components/Player/index.jsx
@@ -1,6 +1,7 @@
 import { useRef } from "react";
 import { useFrame } from "@react-three/fiber";
 import { CapsuleCollider, RigidBody, useRapier } from "@react-three/rapier";
+import PropTypes from "prop-types";
 
 import * as RAPIER from "@dimforge/rapier3d-compat";
 import * as THREE from "three";
@@ -12,7 +13,7 @@ const direction = new THREE.Vector3();
 const frontVector = new THREE.Vector3();
 const sideVector = new THREE.Vector3();
 
-export default function Player() {
+export default function Player({ onPositionChange, position }) {
   const playerRef = useRef();
   const { forward, backward, left, right, jump } = usePlayerControl();
 
@@ -54,11 +55,21 @@ export default function Player() {
 
     const { x, y, z } = playerRef.current.translation();
 
+    if (onPositionChange) {
+      onPositionChange({ x, y, z });
+    }
+
     state.camera.position.set(x, y, z);
   });
 
   return (
-    <RigidBody colliders={false} mass={1} ref={playerRef} lockRotations>
+    <RigidBody
+      colliders={false}
+      mass={1}
+      ref={playerRef}
+      lockRotations
+      position={position}
+    >
       <mesh>
         <capsuleGeometry args={[0.5, 0.5]} />
         <CapsuleCollider args={[0.5, 0.5]} />
@@ -66,3 +77,12 @@ export default function Player() {
     </RigidBody>
   );
 }
+
+Player.propTypes = {
+  onPositionChange: PropTypes.func.isRequired,
+  position: PropTypes.arrayOf(PropTypes.number),
+};
+
+Player.defaultProps = {
+  position: [0, 0, 0],
+};

--- a/src/components/StageClearModal/index.jsx
+++ b/src/components/StageClearModal/index.jsx
@@ -1,5 +1,8 @@
-import PropTypes from "prop-types";
 import styled from "styled-components";
+
+import { useDispatch } from "react-redux";
+import { setStage } from "../../redux/stageSlice";
+import { setIsStageCleared } from "../../redux/stageClearSlice";
 
 const ModalContainer = styled.div`
   display: flex;
@@ -31,11 +34,12 @@ const CloseButton = styled.button`
   font-size: 16px;
 `;
 
-export default function StageClearModal({ onClose }) {
-  function handleModalClick(event) {
-    if (event.target === event.currentTarget) {
-      onClose();
-    }
+export default function StageClearModal() {
+  const dispatch = useDispatch();
+
+  function handleModalClick() {
+    dispatch(setIsStageCleared(false));
+    dispatch(setStage(2));
   }
 
   return (
@@ -43,12 +47,8 @@ export default function StageClearModal({ onClose }) {
       <ModalContent>
         <h2>Congratulations!</h2>
         <p>You have cleared the stage. Would you like to play next stage?</p>
-        <CloseButton onClick={onClose}>Next Stage</CloseButton>
+        <CloseButton onClick={handleModalClick}>Next Stage</CloseButton>
       </ModalContent>
     </ModalContainer>
   );
 }
-
-StageClearModal.propTypes = {
-  onClose: PropTypes.func.isRequired,
-};

--- a/src/components/Stages/Stages.jsx
+++ b/src/components/Stages/Stages.jsx
@@ -3,9 +3,10 @@ import { useSelector } from "react-redux";
 
 import Tutorial from "./Tutorial";
 import StageOne from "./StageOne";
+// import StageTwo from "./StageTwo";
 
 export default function Stages() {
-  const currentStage = useSelector((state) => state.stage.stage);
+  const currentStage = useSelector((state) => state.stages.stage);
 
   const renderStageComponent = () => {
     switch (currentStage) {
@@ -19,6 +20,8 @@ export default function Stages() {
         );
       case 1:
         return <StageOne />;
+      // case 2:
+      // return <StageTwo />;
       default:
         return null;
     }

--- a/src/components/models/StageOnePortal.jsx
+++ b/src/components/models/StageOnePortal.jsx
@@ -15,7 +15,7 @@ export default function StageOnePortal({ scale, rotation }) {
       scale={scale}
       type="fixed"
       rotation={rotation}
-      position={[-19.5, 10, 0]}
+      position={[-19.5, 6, 0]}
       colliders={false}
     >
       <primitive object={gltf.scene} />

--- a/src/redux/stageSlice.jsx
+++ b/src/redux/stageSlice.jsx
@@ -3,7 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 const stageSlice = createSlice({
   name: "stages",
   initialState: {
-    stage: 0,
+    stageLevel: 0,
   },
   reducers: {
     setStage: (state, action) => {

--- a/src/redux/stageSlice.jsx
+++ b/src/redux/stageSlice.jsx
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const stageSlice = createSlice({
-  name: "stage",
+  name: "stages",
   initialState: {
     stage: 0,
   },

--- a/src/redux/store.jsx
+++ b/src/redux/store.jsx
@@ -1,13 +1,13 @@
 import { configureStore } from "@reduxjs/toolkit";
 import logger from "redux-logger";
 
-import stage from "./stageSlice";
+import stages from "./stageSlice";
 import stageClear from "./stageClearSlice";
 import elapsedTimer from "./elapsedSlice";
 
 const store = configureStore({
   reducer: {
-    stage,
+    stages,
     stageClear,
     elapsedTimer,
   },


### PR DESCRIPTION
###  [[FE] 스테이지 클리어 화면 구현](https://www.notion.so/a89179ac73574dfcb7739afd6ec533b0?v=e72d85a81d504d04893f31bcaa6f28dd&p=6c35d6b9472a4ebd8bea7b16fb0699bb&pm=s)

### 설명

- 스테이지1의 클리어 조건이 성립되었을 때 다음 스테이지를 렌더링 하는 기능을 구현했습니다.
- pointerLock 을 lock 하고 unlock 하는 용도인 `controlsRef`를 dragControls 컴포넌트에서 한단계 위인 stageOne으로 올렸습니다. 이유는 modal 창이 렌더링 되었을 때 pointerLock이 적용되어 있어 버튼을 클릭하지 못하는 상황이 발생했기 때문에 pointerLock 을 unlock 해주기 위해 올렸습니다.
- `Player` Component 에서 전달되는 onPositionChange 함수는 현재 플레이어의 좌표가 어딘지 알기 위해 넘겨주고 있습니다. 해당 함수가 실행 되면서 플레이어가 움직이는 현재 좌표를 알 수 있습니다. `({ x, y, z })`

### 리뷰 받고 싶은 내용 or 컨펌 필요 부분

- 오류가 있거나 인덴팅 부분 잘못된게 있다면 코멘트 남겨주시면 바로 수정해놓도록 하겠습니다 감사합니다.

### 기타 내용

![clearstage](https://github.com/howinteraction/interaction/assets/126459089/1cf5c606-8265-48eb-9b45-7254c31cc6a5)

### PR전 확인사항

- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.