### PR TITLE
refactor: 게임 시작 기능 및 레이아웃 수정

### DIFF
--- a/src/components/CameraMotion/index.jsx
+++ b/src/components/CameraMotion/index.jsx
@@ -1,7 +1,5 @@
-import { useRef } from "react";
-import PropTypes from "prop-types";
-import { PointerLockControls } from "@react-three/drei";
 import { useFrame, useThree } from "@react-three/fiber";
+import PropTypes from "prop-types";
 
 import * as THREE from "three";
 
@@ -10,23 +8,14 @@ export default function CameraMotion({
   lerpFactor,
   targetDirection,
 }) {
-  const { camera, gl } = useThree();
-  const controls = useRef();
+  const { camera } = useThree();
   const targetPositionVector = new THREE.Vector3(...targetPosition);
   const targetDirectionVector = new THREE.Vector3(...targetDirection);
 
-  if (controls.current && controls.current.isLocked) {
-    controls.current.unlock();
-  }
-
   useFrame(() => {
-    if (!controls.current.isLocked) {
-      camera.position.lerp(targetPositionVector, lerpFactor);
-      camera.lookAt(targetDirectionVector);
-    }
+    camera.position.lerp(targetPositionVector, lerpFactor);
+    camera.lookAt(targetDirectionVector);
   });
-
-  return <PointerLockControls ref={controls} args={[camera, gl.domElement]} />;
 }
 
 CameraMotion.propTypes = {

--- a/src/components/GameStart/index.jsx
+++ b/src/components/GameStart/index.jsx
@@ -3,20 +3,27 @@ import { useDispatch } from "react-redux";
 import { setStage } from "../../redux/stageSlice";
 import { setIsStageCleared } from "../../redux/stageClearSlice";
 
-import InputInterface from "../InputInterface";
-import Logo from "../models/Tutorial/Logo";
-import CuboidButton from "../models/Tutorial/CuboidButton";
+import {
+  Modal,
+  ModalContent,
+  Input,
+  ErrorMessage,
+  SubmitButton,
+  Light,
+} from "../Styles";
 
 export default function GameStart() {
   const [playerName, setPlayerName] = useState("");
   const [error, setError] = useState("");
+  const [showModal, setShowModal] = useState(true);
   const dispatch = useDispatch();
-
-  const checkUserInputRegExp = /^[가-힣a-zA-Z0-9]{1,10}$/.test(playerName);
+  const checkUserInputRegExp = /^[가-힣a-zA-Z0-9]{2,10}$/.test(playerName);
 
   function handleButtonClick() {
     if (!checkUserInputRegExp) {
-      setError("이름은 한글, 영어, 숫자 혼용 10글자 이내여야 합니다.");
+      setError(
+        "이름은 한글, 영어, 숫자 혼용 2글자 이상 10글자 이하여야 합니다.",
+      );
       return;
     }
 
@@ -40,43 +47,39 @@ export default function GameStart() {
     setError("");
     dispatch(setStage(1));
     dispatch(setIsStageCleared(false));
+    setShowModal(false);
   }
 
   function handleInputChange(name) {
     setPlayerName(name);
+    setError("");
+  }
 
-    if (name === "" || /^[가-힣a-zA-Z0-9]{1,10}$/.test(name)) {
-      setError("");
+  function handleKeyDown(event) {
+    if (event.key === "Enter") {
+      handleButtonClick();
     }
   }
 
   return (
-    <>
-      <Logo
-        position={[35, 23, 0]}
-        scale={[25, 15, 0]}
-        rotation={[0.33, 1.5, -0.35]}
-      />
-      <InputInterface
-        position={[35, 14, 0]}
-        rotation={[0.6, 1.6, -0.59]}
-        width="500px"
-        height="150px"
-        fontSize="80px"
-        errorMessage={error}
-        onChange={handleInputChange}
-      />
-      <CuboidButton
-        position={[35, 7, 0]}
-        args={[12, 3, 3]}
-        rotation={[11.05, 5, -7.8]}
-        onClick={(event) => {
-          event.stopPropagation();
-          handleButtonClick();
-        }}
-        color="blue"
-        text="Start Button"
-      />
-    </>
+    showModal && (
+      <Modal $show={showModal}>
+        <ModalContent>
+          <Input
+            type="text"
+            value={playerName}
+            onChange={(e) => handleInputChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="이름을 입력하세요"
+            $isError={!!error}
+          />
+          {error && <ErrorMessage>{error}</ErrorMessage>}
+          <SubmitButton onClick={handleButtonClick}>
+            game start
+            <Light />
+          </SubmitButton>
+        </ModalContent>
+      </Modal>
+    )
   );
 }

--- a/src/components/GameStart/index.jsx
+++ b/src/components/GameStart/index.jsx
@@ -68,7 +68,7 @@ export default function GameStart() {
           <Input
             type="text"
             value={playerName}
-            onChange={(e) => handleInputChange(e.target.value)}
+            onChange={(event) => handleInputChange(event.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="이름을 입력하세요"
             $isError={!!error}

--- a/src/components/GameStart/index.jsx
+++ b/src/components/GameStart/index.jsx
@@ -15,7 +15,7 @@ import {
 export default function GameStart() {
   const [playerName, setPlayerName] = useState("");
   const [error, setError] = useState("");
-  const [showModal, setShowModal] = useState(true);
+  const [isModalVisible, setIsModalVisible] = useState(true);
   const dispatch = useDispatch();
   const checkUserInputRegExp = /^[가-힣a-zA-Z0-9]{2,10}$/.test(playerName);
 
@@ -47,7 +47,7 @@ export default function GameStart() {
     setError("");
     dispatch(setStage(1));
     dispatch(setIsStageCleared(false));
-    setShowModal(false);
+    setIsModalVisible(false);
   }
 
   function handleInputChange(name) {
@@ -62,8 +62,8 @@ export default function GameStart() {
   }
 
   return (
-    showModal && (
-      <Modal $show={showModal}>
+    isModalVisible && (
+      <Modal $show={isModalVisible}>
         <ModalContent>
           <Input
             type="text"

--- a/src/components/HexSphereWithDrag/index.jsx
+++ b/src/components/HexSphereWithDrag/index.jsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { useDrag } from "@use-gesture/react";
+import { useDispatch } from "react-redux";
+import { useFrame, useThree } from "@react-three/fiber";
+import PropTypes from "prop-types";
+
+import HexSphere from "../models/StageOne/HexSphere";
+import { setIsStageCleared } from "../../redux/stageClearSlice";
+import { DESCENT_VELOCITY } from "../../utils/constants";
+
+export default function HexSphereWithDrag({ initialPosition }) {
+  const dispatch = useDispatch();
+
+  function checkTutorialClear(positionX) {
+    const leftToleranceRange = -4;
+    const rightToleranceRange = 1;
+
+    return positionX > leftToleranceRange && positionX < rightToleranceRange;
+  }
+
+  const [position, setPosition] = useState(initialPosition);
+  const [isDropping, setIsDropping] = useState(false);
+  const { size, viewport } = useThree();
+  const aspect = size.width / viewport.width;
+
+  const bind = useDrag(({ delta: [x, y], down }) => {
+    const [, , z] = position;
+    const dragToWallAllowance = -19;
+    const dragToGroundAllowance = 3.6;
+
+    if (down) {
+      if (position[0] < dragToWallAllowance) {
+        setPosition((prev) => [dragToWallAllowance, prev[1] - y / aspect, z]);
+      } else if (position[1] < dragToGroundAllowance) {
+        setPosition((prev) => [prev[0] + x / aspect, dragToGroundAllowance, z]);
+      } else {
+        setPosition((prev) => [prev[0] + x / aspect, prev[1] - y / aspect, z]);
+      }
+    } else {
+      setIsDropping(true);
+    }
+  });
+
+  useFrame(() => {
+    if (isDropping) {
+      const [currentX, currentY, currentZ] = position;
+      const sphereRadius = 3;
+      const groundToleranceRange = 0.6;
+
+      setPosition([currentX, currentY - DESCENT_VELOCITY, currentZ]);
+
+      const isReachedGround =
+        currentY - DESCENT_VELOCITY < sphereRadius + groundToleranceRange;
+
+      if (isReachedGround) {
+        setIsDropping(false);
+
+        if (checkTutorialClear(currentX)) {
+          dispatch(setIsStageCleared(true));
+        }
+      }
+    }
+  });
+
+  return <HexSphere position={position} {...bind()} />;
+}
+
+HexSphereWithDrag.propTypes = {
+  initialPosition: PropTypes.arrayOf(PropTypes.number),
+};
+
+HexSphereWithDrag.defaultProps = {
+  initialPosition: [8, 2.9, 5],
+};

--- a/src/components/Stages/StageOne.jsx
+++ b/src/components/Stages/StageOne.jsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { Canvas } from "@react-three/fiber";
 import { Physics, RigidBody } from "@react-three/rapier";
 
-import Aim from "../Aim";
+import { Aim } from "../Styles";
 import Player from "../Player";
 import DragControl from "../DragControl";
 import Stopwatch from "../Stopwatch";

--- a/src/components/Stages/StageTwo.jsx
+++ b/src/components/Stages/StageTwo.jsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { Canvas } from "@react-three/fiber";
 import { Physics, RigidBody, CuboidCollider } from "@react-three/rapier";
 
-import Aim from "../Aim";
+import { Aim } from "../Styles";
 import Player from "../Player";
 import DragControl from "../DragControl";
 import VisualIllusion from "../VisualIllusion";

--- a/src/components/Stages/Stages.jsx
+++ b/src/components/Stages/Stages.jsx
@@ -1,4 +1,3 @@
-import { Canvas } from "@react-three/fiber";
 import { useSelector } from "react-redux";
 
 import Tutorial from "./Tutorial";
@@ -12,13 +11,7 @@ export default function Stages() {
   const renderStageComponent = () => {
     switch (currentStage) {
       case 0:
-        return (
-          <Canvas
-            camera={{ near: 0.1, far: 1000, position: [0, 7, 23], fov: 80 }}
-          >
-            <Tutorial />
-          </Canvas>
-        );
+        return <Tutorial />;
       case 1:
         return <StageOne />;
       case 2:

--- a/src/components/Stages/Tutorial.jsx
+++ b/src/components/Stages/Tutorial.jsx
@@ -1,104 +1,54 @@
-import { useState } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import { useThree, useFrame } from "@react-three/fiber";
+import { useSelector } from "react-redux";
+import { Canvas } from "@react-three/fiber";
 import { RigidBody, Physics } from "@react-three/rapier";
-import { useDrag } from "@use-gesture/react";
 
 import CameraMotion from "../CameraMotion";
 import GameStart from "../GameStart";
 
+import Logo from "../models/Tutorial/Logo";
 import TutorialBackground from "../models/Tutorial/TutorialBackground";
 import TutorialTitle from "../models/Tutorial/TutorialTitle";
 import Plane from "../models/Tutorial/Plane";
-import HexSphere from "../models/StageOne/HexSphere";
 
-import { setIsStageCleared } from "../../redux/stageClearSlice";
-import { DESCENT_VELOCITY } from "../../utils/constants";
+import HexSphereWithDrag from "../HexSphereWithDrag";
 
 export default function Tutorial() {
-  const dispatch = useDispatch();
   const isStageCleared = useSelector(
     (state) => state.stageClear.isStageCleared,
   );
-  const [position, setPosition] = useState([8, 2.9, 5]);
-  const [isDropping, setIsDropping] = useState(false);
-
-  const { size, viewport } = useThree();
-  const aspect = size.width / viewport.width;
-
-  const bind = useDrag(({ delta: [x, y], down }) => {
-    const [, , z] = position;
-    const dragToWallAllowance = -19;
-    const dragToGroundAllowance = 3.6;
-
-    if (down) {
-      if (position[0] < dragToWallAllowance) {
-        setPosition((prev) => [dragToWallAllowance, prev[1] - y / aspect, z]);
-      } else if (position[1] < dragToGroundAllowance) {
-        setPosition((prev) => [prev[0] + x / aspect, dragToGroundAllowance, z]);
-      } else {
-        setPosition((prev) => [prev[0] + x / aspect, prev[1] - y / aspect, z]);
-      }
-    } else {
-      setIsDropping(true);
-    }
-  });
-
-  function checkTutorialClear(positionX) {
-    const leftToleranceRange = -4;
-    const rightToleranceRange = 1;
-
-    return positionX > leftToleranceRange && positionX < rightToleranceRange;
-  }
-
-  useFrame(() => {
-    if (isDropping) {
-      const [currentX, currentY, currentZ] = position;
-      const sphereRadius = 3;
-      const groundToleranceRange = 0.6;
-
-      setPosition([currentX, currentY - DESCENT_VELOCITY, currentZ]);
-
-      const isReachedGround =
-        currentY - DESCENT_VELOCITY < sphereRadius + groundToleranceRange;
-
-      if (isReachedGround) {
-        setIsDropping(false);
-
-        if (checkTutorialClear(currentX)) {
-          dispatch(setIsStageCleared(true));
-        }
-      }
-    }
-  });
 
   return (
     <>
-      <ambientLight intensity={2} />
-      <Physics>
-        <TutorialBackground />
-        <TutorialTitle />
-        <RigidBody>
-          <HexSphere position={position} {...bind()} />
-        </RigidBody>
-        <Plane
-          position={[-2, 0.01, 5]}
-          rotateX={-Math.PI / 2}
-          rotateY={0}
-          color="green"
-          args={[8, 8]}
-        />
-      </Physics>
-      {isStageCleared && (
-        <>
+      <Canvas camera={{ near: 0.1, far: 1000, position: [0, 7, 23], fov: 80 }}>
+        <ambientLight intensity={2} />
+        <Physics>
+          <TutorialBackground />
+          <TutorialTitle />
+          <RigidBody>
+            <HexSphereWithDrag />
+          </RigidBody>
+          <Plane
+            position={[-2, 0.01, 5]}
+            rotateX={-Math.PI / 2}
+            rotateY={0}
+            color="green"
+            args={[8, 8]}
+          />
+        </Physics>
+        {isStageCleared && (
           <CameraMotion
             targetPosition={[60, 10, 0]}
             lerpFactor={0.01}
             targetDirection={[0, 15, 0]}
           />
-          <GameStart />
-        </>
-      )}
+        )}
+        <Logo
+          position={[35, 24, 0]}
+          scale={[20, 10, 0]}
+          rotation={[0.33, 1.5, -0.35]}
+        />
+      </Canvas>
+      {isStageCleared && <GameStart />}
     </>
   );
 }

--- a/src/components/Styles/index.jsx
+++ b/src/components/Styles/index.jsx
@@ -1,0 +1,109 @@
+import styled, { keyframes } from "styled-components";
+
+export const Aim = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  transform: translate3d(-50%, -50%, 0);
+  border: 2px solid white;
+  z-index: 2;
+`;
+
+export const Modal = styled.div`
+  display: ${({ $show }) => ($show ? "block" : "none")};
+  position: fixed;
+  text-align: center;
+  z-index: 2;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+`;
+
+export const ModalContent = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 20px;
+  border: 1px solid #888;
+  width: 50%;
+  max-width: 500px;
+  border-radius: 8px;
+  background-color: rgba(0, 0, 0, 0.7);
+`;
+
+export const Input = styled.input`
+  color: #03e9f4;
+  font-size: 16px;
+  display: block;
+  width: 60%;
+  padding: 12px 20px;
+  margin: 8px auto 20px;
+  background-color: transparent;
+  box-sizing: border-box;
+  border: 2px solid ${({ $isError }) => ($isError ? "#f44336" : "#ccc")};
+  border-radius: 4px;
+  &:focus {
+    border-color: ${({ $isError }) => ($isError ? "#f44336" : "#4CAF50")};
+  }
+  ${({ $isError }) =>
+    $isError &&
+    `
+    background-color: rgba(0, 0, 0, 1);
+  `}
+`;
+
+export const ErrorMessage = styled.div`
+  color: #f44336;
+  font-size: 16px;
+  margin-bottom: 15px;
+`;
+
+export const SubmitButton = styled.button`
+  position: relative;
+  display: inline-block;
+  padding: 15px 20px;
+  color: #03e9f4;
+  font-size: 16px;
+  text-transform: uppercase;
+  overflow: hidden;
+  transition: 0.5s;
+  letter-spacing: 4px;
+  cursor: pointer;
+  background-color: transparent;
+  border-image: linear-gradient(90deg, transparent, #03e9f4, transparent) 1;
+  border: 1px solid transparent;
+
+  &:hover {
+    background-image: linear-gradient(
+      45deg,
+      rgba(3, 233, 244, 0.3),
+      rgba(3, 233, 244, 0.7)
+    );
+    box-shadow: 0 0 15px #03e9f4;
+    border-image: none;
+  }
+`;
+
+export const move = keyframes`
+  0% {
+    left: -100%;
+  }
+  50%,100% {
+    left: 100%;
+  }
+`;
+
+export const Light = styled.span`
+  position: absolute;
+  display: block;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, #03e9f4);
+  animation: ${move} 1s linear infinite;
+`;

--- a/src/components/models/Tutorial/Logo.jsx
+++ b/src/components/models/Tutorial/Logo.jsx
@@ -1,4 +1,5 @@
-import { useLoader } from "@react-three/fiber";
+import { useRef } from "react";
+import { useFrame, useLoader } from "@react-three/fiber";
 import PropTypes from "prop-types";
 
 import * as THREE from "three";
@@ -8,9 +9,16 @@ export default function Logo({ position, scale, rotation }) {
     THREE.TextureLoader,
     "/assets/images/tutorial-picture/logo-removebg.png",
   );
+  const logoRef = useRef();
+
+  useFrame(() => {
+    logoRef.current.rotation.x += 0.005;
+    logoRef.current.rotation.y += 0.005;
+    logoRef.current.rotation.z += 0.005;
+  });
 
   return (
-    <mesh position={position} scale={scale} rotation={rotation}>
+    <mesh position={position} scale={scale} rotation={rotation} ref={logoRef}>
       <planeGeometry attach="geometry" />
       <meshStandardMaterial
         attach="material"


### PR DESCRIPTION
### [[FE] (튜토리얼 클리어시) 게임 시작 화면 레이아웃](https://www.notion.so/FE-0f823077ac964266946492879db59cc0?pvs=4) / [[FE] (튜토리얼 클리어시) 게임 시작 기능](https://www.notion.so/FE-7f84edf96ca74931a12aa77f2cf7e516?pvs=4)

### 설명
**튜토리얼 클리어 시  나타나는 `GameStart` 컴포넌트의 레이아웃 및 기능 등을 수정하였습니다.
내용은 아래와 같습니다.**
 -  기존의 `GameStart` 컴포넌트에서 사용하던 `InputInterface`, `CuboidButton` 컴포넌트를 사용하지 않고, 모달창을 띄워주도록 수정하였습니다.
 - `styled-components` 를 사용한 요소들은 전부 Styles 폴더의 index.jsx로 보내주었습니다.
 -  `CameraMotion` 내에 있던 PointerLockControls와 관련된 로직을 삭제하였습니다.
 - 기존 Tutorial 에 있던  드래그 관련 코드를 `HexSphereWithDrag`  로 수정 후 파일 분리 하였습니다.


### 리뷰 받고 싶은 내용 or 컨펌 필요 부분
 - `CameraMotion` 의 `PointerLockControls` 관련 로직을 전부 지워주었습니다. 확인 부탁드립니다.
 - 분리된 코드 및 파일인 Styles, HexSphereWithDrag 변수명, 로직 등 확인 부탁드립니다.

### PR전 확인사항

- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.

### 스크린샷
![game_start_layout](https://github.com/howinteraction/interaction/assets/116258834/a16bcb20-2579-408d-9cd6-7f106d79b619)


![game_start](https://github.com/howinteraction/interaction/assets/116258834/71bc1d41-e39d-4bd9-9e23-71601bb4be21)

![game_start_2](https://github.com/howinteraction/interaction/assets/116258834/a3f9ac22-221a-404e-8c6a-42d487c5f308)

![game_start_3](https://github.com/howinteraction/interaction/assets/116258834/5f9d88cd-f8cf-4783-bf0c-9bd48f7ad55d)
