### PR TITLE
fix: 튜토리얼, 스테이지1 맵 변경, cuboid 설정 및 DragControl boxsize 최대값 설정

### DIFF
--- a/src/components/DragControl/index.jsx
+++ b/src/components/DragControl/index.jsx
@@ -137,14 +137,20 @@ export default function DragControl({
           const heightRatio = Math.min(currentHeight / maxHeight, 1);
           const scale = 1 + heightRatio;
           const newSize = boxSize * scale;
+          const maximumSize = 5;
+          const adjustedSize = newSize > maximumSize ? maximumSize : newSize;
 
           selectedRigidBody
             .collider(0)
             .setHalfExtents(
-              new THREE.Vector3(newSize / 2, newSize / 2, newSize / 2),
+              new THREE.Vector3(
+                adjustedSize / 2,
+                adjustedSize / 2,
+                adjustedSize / 2,
+              ),
             );
 
-          meshScaleRef.current = newSize;
+          meshScaleRef.current = adjustedSize;
         } else {
           const newSize = boxSize * distanceRatio;
           const minimumSize = 0.5;

--- a/src/components/Stages/StageOne.jsx
+++ b/src/components/Stages/StageOne.jsx
@@ -52,8 +52,8 @@ export default function StageOne() {
             minX={-46}
             maxX={46}
             maxY={29}
-            minZ={-19}
-            maxZ={19}
+            minZ={-21.5}
+            maxZ={21.5}
             boxSize={boxSize}
             setBoxSize={setBoxSize}
             controlsRef={controlsRef}

--- a/src/components/models/Tutorial/TutorialBackground.jsx
+++ b/src/components/models/Tutorial/TutorialBackground.jsx
@@ -18,8 +18,8 @@ export default function TutorialBackground() {
       <CuboidCollider args={[50, 1, 50]} position={[0, 29, 0]} />
       <CuboidCollider args={[1, 50, 50]} position={[-48, 10, 0]} />
       <CuboidCollider args={[1, 50, 50]} position={[48, 10, 0]} />
-      <CuboidCollider args={[50, 50, 1]} position={[0, 10, -21]} />
-      <CuboidCollider args={[50, 50, 1]} position={[0, 10, 21]} />
+      <CuboidCollider args={[50, 50, 1]} position={[0, 10, -23.9]} />
+      <CuboidCollider args={[50, 50, 1]} position={[0, 10, 23.9]} />
     </>
   );
 }


### PR DESCRIPTION
### 설명

- 튜토리얼, 스테이지1 맵 수정하였습니다.
- 맵 수정으로 인해 벽 간의 cuboid 값이 달라져 수정하였습니다.
- dragControl시 플레이어와 물체의 거리가 멀어짐에 따라 box 사이즈가 커지는 조건에서, 최대값을 정해놓지 않으면 boxSize가 맵전체를 덮는 버그가 생겨, maxSize 값을 지정해주었습니다.

### 리뷰 받고 싶은 내용 or 컨펌 필요 부분
- Cuboid값을 설정해주긴 했는데, 착시가 적용되는 (크기가 커지고 작아지는) 물체를 드래그 할 때 크기 변화에 따라 `cuboid` 설정해준 값을 넘어버려서 ( 메쉬가 벽을 통과하는 ) 현상이 생겨 
- 착시가 적용되지 않는 물체와 비교하면서 어느정도 조율을해 `cuboid` 값과 `dragControl`의 `maxZ`, `minZ` 값들을 설정해주었습니다. 확인 부탁드리겠습니다.

### PR전 확인사항

- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.

### (필요시) 스크린샷
![스크린샷 2024-02-24 16 32 09](https://github.com/howinteraction/interaction/assets/126459089/a34e6e0e-01d7-4f6d-8871-0a94324a7d00)

![스크린샷 2024-02-24 16 32 31](https://github.com/howinteraction/interaction/assets/126459089/25a812e0-8172-4f25-a084-0dbbd374dbda)

