### PR TITLE
test: visualIllusion 컴포넌트 테스트 코드 추가

### DIFF
--- a/src/spec/src/components/VisualIllusion/VisualIllusion.spec.jsx
+++ b/src/spec/src/components/VisualIllusion/VisualIllusion.spec.jsx
@@ -1,0 +1,50 @@
+import { renderHook, act } from "@testing-library/react";
+import { useSelector, useDispatch } from "react-redux";
+
+import { useThree } from "@react-three/fiber";
+
+import { vi, describe, it, expect } from "vitest";
+import VisualIllusion from "../../../../components/VisualIllusion";
+import { setIsCombined } from "../../../../redux/twoIllusionSlice";
+
+vi.mock("react-redux", () => ({
+  useSelector: vi.fn(),
+  useDispatch: vi.fn(),
+}));
+
+vi.mock("@react-three/fiber", () => ({
+  useThree: vi.fn(),
+  useFrame: vi.fn().mockImplementation((callback) => {
+    global.frameCallback = callback;
+  }),
+}));
+
+describe("VisualIllusion", () => {
+  it("카메라의 position과 rotation이 유효범위에 들어오면 setIsCombined가 true로 바뀌어야 한다.", () => {
+    const mockCamera = {
+      position: { x: -6, y: 2, z: -2.75 },
+      rotation: { x: 2.15, y: -1.25, z: 2.2 },
+    };
+
+    const mockDispatch = vi.fn();
+
+    vi.mocked(useDispatch).mockReturnValue(mockDispatch);
+    vi.mocked(useSelector).mockImplementation((selector) =>
+      selector({
+        twoIllusion: { isCombined: false },
+      }),
+    );
+
+    vi.mocked(useThree).mockReturnValue({
+      camera: mockCamera,
+    });
+
+    renderHook(() => VisualIllusion());
+
+    act(() => {
+      global.frameCallback();
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(setIsCombined(true));
+  });
+});


### PR DESCRIPTION
### 설명

- visualIllusion 컴포넌트 테스트 코드 추가하였습니다.
- 카메라의 position과 rotation이 유효범위에 들어오면 setIsCombined가 true로 바뀌어야 하는 테스트 코드 입니다.

### 리뷰 받고 싶은 내용 or 컨펌 필요 부분

- 테스트 코드에 틀린게 있으면 리뷰 부탁드리겠습니다.

### PR전 확인사항

- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.
