### PR TITLE
test: 컴포넌트들 대한 테스트 코드 추가

### DIFF
--- a/src/components/models/StageThree/StageThreeHayStack.jsx
+++ b/src/components/models/StageThree/StageThreeHayStack.jsx
@@ -29,3 +29,5 @@ export default function StageThreeHayStack() {
 
   return null;
 }
+
+useGLTF.preload("/assets/glb/haystack.glb");

--- a/src/spec/src/components/DragControl/DragControl.spec.jsx
+++ b/src/spec/src/components/DragControl/DragControl.spec.jsx
@@ -1,0 +1,61 @@
+import { render, fireEvent } from "@testing-library/react";
+
+import * as THREE from "three";
+import { describe, it, vi, beforeEach } from "vitest";
+import { Provider } from "react-redux";
+import DragControl from "../../../../components/DragControl";
+import store from "../../../../redux/store";
+
+describe("DragControl", () => {
+  beforeEach(() => {
+    vi.mock("@react-three/fiber", () => ({
+      useFrame: vi.fn().mockImplementation((callback) => {
+        global.frameCallback = callback;
+      }),
+      useThree: vi.fn(() => ({
+        camera: new THREE.PerspectiveCamera(),
+      })),
+    }));
+
+    vi.mock("@react-three/drei", () => ({
+      PointerLockControls: vi.fn(() => null),
+    }));
+
+    vi.mock("@react-three/rapier", () => ({
+      useRapier: vi.fn(() => ({
+        world: {
+          castRay: vi.fn(() => ({
+            collider: { parent: vi.fn(() => ({ handle: 1 })) },
+          })),
+          getRigidBody: vi.fn(() => ({
+            userData: { isDraggable: true },
+            setBodyType: vi.fn(),
+            setTranslation: vi.fn(),
+            collider: vi.fn(),
+          })),
+        },
+      })),
+    }));
+  });
+
+  const controlsRef = {
+    current: {
+      lock: vi.fn(),
+    },
+  };
+
+  it("DragControl 훅이 렌더링 되어야 한다.", () => {
+    render(
+      <Provider store={store}>
+        <DragControl
+          minX={-10}
+          maxX={10}
+          maxY={10}
+          minZ={-10}
+          maxZ={10}
+          controlsRef={controlsRef}
+        />
+      </Provider>,
+    );
+  });
+});

--- a/src/spec/src/components/DragControl/DragControl.spec.jsx
+++ b/src/spec/src/components/DragControl/DragControl.spec.jsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from "@testing-library/react";
 import * as THREE from "three";
 import { describe, it, vi, beforeEach } from "vitest";
 import { Provider } from "react-redux";
+import React from "react";
 import DragControl from "../../../../components/DragControl";
 import store from "../../../../redux/store";
 
@@ -32,6 +33,7 @@ describe("DragControl", () => {
             setBodyType: vi.fn(),
             setTranslation: vi.fn(),
             collider: vi.fn(),
+            translation: vi.fn(() => new THREE.Vector3(1, 2, 3)),
           })),
         },
       })),
@@ -57,5 +59,27 @@ describe("DragControl", () => {
         />
       </Provider>,
     );
+  });
+
+  it("클릭 이벤트 시 드래그 시작", () => {
+    render(
+      <Provider store={store}>
+        <DragControl
+          minX={-10}
+          maxX={10}
+          maxY={10}
+          minZ={-10}
+          maxZ={10}
+          controlsRef={controlsRef}
+          selectedHandle={1}
+          isDragging
+          clickedPosition={new THREE.Vector3(0, 1, 2)}
+        />
+      </Provider>,
+    );
+
+    fireEvent.click(document.body);
+
+    global.frameCallback();
   });
 });

--- a/src/spec/src/components/Subtitle/Subtitle.spec.jsx
+++ b/src/spec/src/components/Subtitle/Subtitle.spec.jsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+import Subtitle from "../../../../components/Subtitle";
+import { SUBTITLE_TIME } from "../../../../utils/constants";
+
+vi.mock("@react-three/drei", () => ({
+  // eslint-disable-next-line react/prop-types
+  Text: ({ children }) => <text>{children}</text>,
+}));
+
+describe("Subtitle 컴포넌트", () => {
+  it("SubtitleTime 이후에 컴포넌트가 사라져야 함", () => {
+    const { container, rerender } = render(
+      <Subtitle
+        position={[0, 0, 0]}
+        rotation={[0, 0, 0]}
+        subtitle="테스트 자막"
+      />,
+    );
+
+    expect(container).toBeInTheDocument();
+
+    vi.useFakeTimers(SUBTITLE_TIME);
+    rerender(
+      <Subtitle
+        position={[0, 0, 0]}
+        rotation={[0, 0, 0]}
+        subtitle="테스트 자막"
+      />,
+    );
+
+    expect(container).toBeInTheDocument();
+  });
+});

--- a/src/spec/src/models/StageThreeModels.spec.jsx
+++ b/src/spec/src/models/StageThreeModels.spec.jsx
@@ -3,10 +3,15 @@ import ReactThreeTestRenderer from "@react-three/test-renderer";
 import * as THREE from "three";
 import { useGLTF } from "@react-three/drei";
 
+import { Provider } from "react-redux";
+import store from "../../../redux/store";
+
 import StageThreeBackGround from "../../../components/models/StageThree/StageThreeBackGround";
 import StageThreeSky from "../../../components/models/StageThree/StageThreeSky";
 import StageThreeCloud from "../../../components/models/StageThree/StageThreeCloud";
 import StageThreeShip from "../../../components/models/StageThree/StageThreeShip";
+import StageThreeHayStack from "../../../components/models/StageThree/StageThreeHayStack";
+import StageThreeStone from "../../../components/models/StageThree/StageThreeStone";
 
 describe("StageThree의 useGLTF로 로드 및 렌더링 하는 컴포넌트", () => {
   beforeEach(() => {
@@ -81,5 +86,41 @@ describe("StageThree의 useGLTF로 로드 및 렌더링 하는 컴포넌트", ()
 
     expect(useGLTF).toHaveBeenCalledWith("/assets/glb/stage3-ship.glb");
     expect(useGLTF.preload).toHaveBeenCalledWith("/assets/glb/stage3-ship.glb");
+  });
+
+  it("StageThreeHayStack 컴포넌트가 useGLTF를 통해 scene을 로드하고 RigidBody 컴포넌트를 포함한다", async () => {
+    await ReactThreeTestRenderer.act(async () => {
+      const renderer = await ReactThreeTestRenderer.create(
+        <Provider store={store}>
+          <StageThreeHayStack />,
+        </Provider>,
+      );
+
+      expect(vi.mocked(useGLTF).mock.calls.length).toBeGreaterThan(0);
+
+      const RigidBody = renderer.scene.findAllByType("RigidBody");
+
+      expect(RigidBody).not.toBeNull();
+    });
+
+    expect(useGLTF).toHaveBeenCalledWith("/assets/glb/haystack.glb");
+    expect(useGLTF.preload).toHaveBeenCalledWith("/assets/glb/haystack.glb");
+  });
+
+  it("StageThreeStone 컴포넌트가 GLTF 모델을 로드하고 Clone 을 포함한다", async () => {
+    await ReactThreeTestRenderer.act(async () => {
+      const renderer = await ReactThreeTestRenderer.create(<StageThreeStone />);
+
+      expect(vi.mocked(useGLTF).mock.calls.length).toBeGreaterThan(0);
+
+      const clone = renderer.scene.findAllByType("primitive");
+
+      expect(clone).not.toBeNull();
+    });
+
+    expect(useGLTF).toHaveBeenCalledWith("/assets/glb/stage3-cloud.glb");
+    expect(useGLTF.preload).toHaveBeenCalledWith(
+      "/assets/glb/stage3-cloud.glb",
+    );
   });
 });


### PR DESCRIPTION
### 설명
- stageThree models에서 haystack, subtitle 컴포넌트, dragControl 컴포넌트 에 대한 테스트 코드 작성하였습니다.

### 기타 내용
- dragcontrol 컴포넌트의 경우 71% 통과 완료 되었습니다.
- 테스트 코드 혹은 설정에 관한 잘못된 부분 발견 해주시면 리뷰 부탁드리겠습니다!

### PR전 확인사항

- [x] 가장 최신 브랜치를 pull 받고 시작했습니다.
- [x] base 브랜치명을 확인했습니다. (튜토리얼 이동기능... , 스테이지1 점프 기능... , ,스테이지2 카메라 이동 기능... ,)
- [x] 코드 컨벤션을 모두 확인 했습니다.
- [x] 리뷰어가 있습니다.
